### PR TITLE
🐱 Base62: Add ToBase62 extension method for Guid

### DIFF
--- a/System/Base62.cs
+++ b/System/Base62.cs
@@ -38,6 +38,12 @@ namespace System
     static partial class Base62
     {
         /// <summary>
+        /// Encodes a Guid into a base62 string.
+        /// </summary>
+        public static string ToBase62(this Guid guid) 
+            => Encode(BigInteger.Abs(new BigInteger(guid.ToByteArray())));
+
+        /// <summary>
         /// Encodes a numeric value into a base62 string.
         /// </summary>
         public static string Encode(BigInteger value)


### PR DESCRIPTION
This shortens a GUID string from 32 chars down to 21/22 without loss of complexity.

Closes #62